### PR TITLE
投稿完了ページの実装

### DIFF
--- a/app/Http/Controllers/FormcontentsController.php
+++ b/app/Http/Controllers/FormcontentsController.php
@@ -18,7 +18,7 @@ class FormcontentsController extends Controller
      */
 
     public function formList(Request $request){
-        $get_session_data = $request->session()->all();
+        $get_session_data = $request->session()->all();
         return view('form_content.input', compact('get_session_data')); // 「resources/views/form_content/input.php」を返す。
     }
     public function confirmation(Request $request){
@@ -26,6 +26,9 @@ class FormcontentsController extends Controller
         $request->session()->put($_POST); //セッションへデータ保存
         $get_session_data = $request->session()->all(); //保存したセッションデータの全て取得
         return view('form_content.confirm', compact('data','get_session_data'));
+    }
+    public function complete(){
+        return view('form_content.complete');
     }
 }
 ?>

--- a/resources/views/form_content/complete.blade.php
+++ b/resources/views/form_content/complete.blade.php
@@ -1,12 +1,14 @@
 <!--自動返信処理（SMTPサーバーを構築する必要あり)-->
 <?php
-require('require/auto-reply.php');
-require('require/session-reset.php');
-require('require/dbconnect.php');
-require('require/dbregister.php');
-require('require/header.html');
+//require('require/auto-reply.php');
+//require('require/session-reset.php');
+//require('require/dbconnect.php');
+//require('require/dbregister.php');
+// require('/require/head.html');
 ?>
 
+@include('require.head')
+<?php var_dump($_POST)?>
 <body>
   <header class="title">お問い合わせフォーム</header>
   <div class="complete-message1">送信が完了しました。<br>お問い合わせ頂きありがとうございました。</div>

--- a/resources/views/form_content/confirm.blade.php
+++ b/resources/views/form_content/confirm.blade.php
@@ -23,22 +23,14 @@
 <?php
 // require('require/header.html');
 ?>
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" type="text/css" href="http://yui.yahooapis.com/3.18.1/build/cssreset/cssreset-min.css">
-  <link rel="stylesheet" href="css/style.css">
-
-  <title>formApp</title>
-</head>
+@include('require.head')
 
 <body>
   <?php //var_dump($_POST); ?>
   <!-- var_dump(変数)  キー名 => 型(バイト数) "値"-->
   <header class="title">お問い合わせフォーム</header>
-  <form action="complete.php" class="form" method="POST">
+  <form action="{{ url('/complete') }}" class="form" method="POST">
+  {{ csrf_field() }}
     <div class=form-contents-wrapper>
       <div class="wrapper">
         <div class="box">件名</div>

--- a/resources/views/form_content/input.blade.php
+++ b/resources/views/form_content/input.blade.php
@@ -1,13 +1,4 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" type="text/css" href="http://yui.yahooapis.com/3.18.1/build/cssreset/cssreset-min.css">
-  <link rel="stylesheet" href="css/style.css">
-
-  <title>formApp</title>
-</head>
+@include('require.head')
 
 <body>
   <?php //var_dump($get_session_data);?>
@@ -24,13 +15,14 @@
             $selected = $get_session_data['title'];
             }?>
           <option name="initial" value=""> 選択してください </option>
-          <option name="opinion" <?php if($selected == "ご意見"){
+          <option name="opinion" <?php if(isset($selected) && $selected == "ご意見"){
             echo "selected";
+            // issetの条件を付けないと$seleceteが定義されていないことになり、エラーが起きる。
             }?>>ご意見</option>
-          <option name="comment" <?php if($selected == "感想"){
+          <option name="comment" <?php if(isset($selected) && $selected == "感想"){
             echo "selected";
             }?>>感想</option>
-          <option name="other" <?php if($selected == "その他"){
+          <option name="other" <?php if(isset($selected) && $selected == "その他"){
             echo "selected";
             }?>>その他</option>
         </select>

--- a/resources/views/require/head.html
+++ b/resources/views/require/head.html
@@ -4,6 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="http://yui.yahooapis.com/3.18.1/build/cssreset/cssreset-min.css">
-  <link rel="stylesheet" href ="style.css">
+  <link rel="stylesheet" href ="css/style.css"> <!-- ホームディレクトリはpublicだから？ -->
   <title>formApp</title>
 </head>

--- a/resources/views/require/validation.php
+++ b/resources/views/require/validation.php
@@ -4,19 +4,19 @@
     foreach ($keys as $key){
       if(empty($_POST[$key])){
         if($key == 'title'){
-          $error[] = "件名を選択してください。";
+          $error[] = "件名を選択してください。"; //"件名を選択してください。"を$error配列に追加
         }
         if($key == 'username'){
-          $error[] = "名前は必須項目です。";
+          $error[] = "名前は必須項目です。"; //"名前は必須項目です。"を$error配列に追加
         }
         if($key == 'email'){
-          $error[] = "メールアドレスは必須項目です。";
+          $error[] = "メールアドレスは必須項目です。"; //"名前は必須項目です。"を$error配列に追加
         }
         if($key == 'phoneNumber'){
-          $error[] = "電話番号は必須項目です。";
+          $error[] = "電話番号は必須項目です。"; //"名前は必須項目です。"を$error配列に追加
         }
         if($key == 'content'){
-          $error[] = "お問い合わせ内容は必須項目です。";
+          $error[] = "お問い合わせ内容は必須項目です。"; //"名前は必須項目です。"を$error配列に追加
         }
       }
     }
@@ -28,10 +28,10 @@
       $error[] = "正しい電話番号を記入してください。";
     }
     //長さに反する場合
-    if(strlen($_POST['username'] >= 60)){
+    if(strlen($_POST['username'] <= 60)){
       $error[] = "名前は60文字以内で記入してください。";
     }
-    if(strlen($_POST['email'] >= 60)){
+    if(strlen($_POST['email'] <= 60)){
       $error[] = "メールアドレスは254文字以内で記入してください。";
     }
     return $error;

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,3 +13,4 @@
 
 Route::get('/', 'FormcontentsController@formlist');
 Route::post('/confirm', 'FormcontentsController@confirmation');
+Route::post('/complete', 'FormcontentsController@complete');


### PR DESCRIPTION
・確認ページから投稿した際のルーティング及びコントローラの記載。
・htmlのhead部分を共通化した。
・問合せ投稿ページの変数($selected)定義条件の変更し、sesssionデータがなくてもページを表示できるよう修正した。